### PR TITLE
Add CSP and offline-ready PWA setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; img-src 'self' https://images.badssl.com; script-src 'self'; style-src 'self'; connect-src 'self'; font-src 'self'; base-uri 'self'; form-action 'self'; worker-src 'self'; manifest-src 'self'"
+    />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/src/index.css" />
     <title>Firebyte Labs</title>
-    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="overflow-hidden">
     <div id="root"></div>

--- a/public/icons/firebyte-logo.svg
+++ b/public/icons/firebyte-logo.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff7b00"/>
+      <stop offset="100%" stop-color="#ff0000"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#grad)" d="M256 32l64 128-64-32-64 96 32 32-32 64 64 32 64-96-32-32 32-64z"/>
+  <text x="50%" y="420" font-size="72" font-family="Arial" fill="#00aaff" text-anchor="middle">FIREBYTE</text>
+  <text x="50%" y="470" font-size="32" font-family="Arial" fill="#00aaff" text-anchor="middle">labs.</text>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "RiggedGuard Rampage React",
+  "short_name": "RiggedGuard",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#00ffa3",
+  "icons": [
+    {
+      "src": "/icons/firebyte-logo.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/firebyte-logo.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RiggedGuard Rampage React</title>
+    <style>
+      body {
+        background: #000;
+        color: #00ffa3;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        text-align: center;
+        padding: 2rem;
+      }
+      a {
+        color: #00ffa3;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Offline mode</h1>
+      <p>The network is unreachable. We'll reconnect as soon as a connection is available.</p>
+    </div>
+  </body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,202 @@
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `riggedguard-cache-${CACHE_VERSION}`;
+const ORIGIN = self.location.origin;
+
+const ASSET_MANIFEST = {
+  '/index.html': [
+    '8Uahgmg6lENYbcBYI4nuPkIcCwDEJjp7YoFLXT+QT/Y=',
+    '4pddxkJvvAzeyl6AsxQiNqNrBScsDfgPmXhlg7tGBC4='
+  ],
+  '/manifest.webmanifest': 'IsJecKKBxxTiAI9bdyX7A+SosdTlS8yiXYObJ0+7Xzk=',
+  '/offline.html': 'fY30/uiEAoyZ0/OqvFDT29H+cpNGiNynyl6mgcfbgFM=',
+  '/icons/firebyte-logo.svg': 'TKMVpbrPj0QXBnqO1vzkps1PiPuBqukl2Fpp3RmdbSw='
+};
+
+class IntegrityError extends Error {
+  constructor(url, expected, actual) {
+    super(`Integrity check failed for ${url}`);
+    this.name = 'IntegrityError';
+    this.url = url;
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      self.skipWaiting();
+      const cache = await caches.open(CACHE_NAME);
+      await Promise.all(
+        Object.entries(ASSET_MANIFEST).map(async ([path, hash]) => {
+          try {
+            await cacheAsset(cache, path, hash);
+          } catch (error) {
+            if (error instanceof IntegrityError) {
+              await notifyIntegrityFailure(error);
+            }
+            throw error;
+          }
+        })
+      );
+    })()
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(event.request.url);
+  if (url.origin !== ORIGIN) {
+    return;
+  }
+
+  const normalizedPath = normalizePath(url.pathname);
+  const expectedHash = ASSET_MANIFEST[normalizedPath];
+
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+
+      if (expectedHash) {
+        const cached = await cache.match(normalizedPath);
+        if (cached) {
+          try {
+            await ensureIntegrity(cached.clone(), expectedHash, normalizedPath);
+            return cached;
+          } catch (error) {
+            if (error instanceof IntegrityError) {
+              await notifyIntegrityFailure(error);
+            }
+            await cache.delete(normalizedPath);
+          }
+        }
+
+        try {
+          const response = await fetchAndVerify(normalizedPath, expectedHash);
+          await cache.put(normalizedPath, response.clone());
+          return response;
+        } catch (error) {
+          if (error instanceof IntegrityError) {
+            await notifyIntegrityFailure(error);
+          }
+          if (event.request.mode === 'navigate') {
+            const fallback = await cache.match('/offline.html');
+            if (fallback) {
+              return fallback;
+            }
+          }
+          throw error;
+        }
+      }
+
+      if (event.request.mode === 'navigate') {
+        try {
+          return await fetch(event.request);
+        } catch (error) {
+          const fallback = await cache.match('/offline.html');
+          if (fallback) {
+            return fallback;
+          }
+          throw error;
+        }
+      }
+
+      const cached = await cache.match(event.request);
+      if (cached) {
+        return cached;
+      }
+
+      try {
+        const response = await fetch(event.request);
+        if (url.origin === ORIGIN) {
+          cache.put(event.request, response.clone()).catch(() => {});
+        }
+        return response;
+      } catch (error) {
+        if (event.request.destination === 'document') {
+          const fallback = await cache.match('/offline.html');
+          if (fallback) {
+            return fallback;
+          }
+        }
+        throw error;
+      }
+    })()
+  );
+});
+
+async function cacheAsset(cache, path, expectedHash) {
+  const response = await fetchAndVerify(path, expectedHash);
+  await cache.put(path, response.clone());
+}
+
+async function fetchAndVerify(path, expectedHash) {
+  const response = await fetch(path, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Request for ${path} failed with status ${response.status}`);
+  }
+  await ensureIntegrity(response.clone(), expectedHash, path);
+  return response;
+}
+
+async function ensureIntegrity(response, expectedHash, url) {
+  const buffer = await response.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  const actualHash = bufferToBase64(digest);
+  if (!matchesExpectedHash(actualHash, expectedHash)) {
+    throw new IntegrityError(url, expectedHash, actualHash);
+  }
+  return actualHash;
+}
+
+async function notifyIntegrityFailure(error) {
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  for (const client of clients) {
+    client.postMessage({
+      type: 'INTEGRITY_ERROR',
+      url: error.url,
+      expected: error.expected,
+      actual: error.actual
+    });
+  }
+}
+
+function bufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function normalizePath(pathname) {
+  if (!pathname || pathname === '/') {
+    return '/index.html';
+  }
+  return pathname;
+}
+
+function matchesExpectedHash(actual, expected) {
+  if (Array.isArray(expected)) {
+    return expected.includes(actual);
+  }
+  return actual === expected;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,3 +2,155 @@ html, body, #root {
   height: 100%;
   margin: 0;
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #000;
+  color: #fff;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.relative {
+  position: relative;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.w-screen {
+  width: 100vw;
+}
+
+.h-screen {
+  height: 100vh;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.w-64 {
+  width: 16rem;
+}
+
+.h-64 {
+  height: 16rem;
+}
+
+.w-80 {
+  width: 20rem;
+}
+
+.object-contain {
+  object-fit: contain;
+}
+
+.bg-black {
+  background-color: #000;
+}
+
+.bg-black\/60 {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.bg-black\/50 {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.bg-white\/10 {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.text-white {
+  color: #fff;
+}
+
+.text-gray-300 {
+  color: #d1d5db;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.p-8 {
+  padding: 2rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.bg-blue-500 {
+  background-color: #3b82f6;
+}
+
+.hover\:bg-blue-600:hover {
+  background-color: #2563eb;
+}
+
+.placeholder-gray-400::placeholder {
+  color: #9ca3af;
+}
+
+.backdrop-blur-lg {
+  backdrop-filter: blur(24px);
+}
+
+.inset-0 {
+  inset: 0;
+}
+
+.bg-black\/60,
+.bg-black\/50,
+.bg-white\/10,
+.bg-blue-500,
+.hover\:bg-blue-600:hover {
+  transition: background-color 0.2s ease-in-out;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,3 +8,30 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <App />
   </React.StrictMode>
 );
+
+if ('serviceWorker' in navigator) {
+  const broadcastIntegrityAlert = (detail) => {
+    window.dispatchEvent(
+      new CustomEvent('service-worker-integrity-alert', { detail })
+    );
+  };
+
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'INTEGRITY_ERROR') {
+      broadcastIntegrityAlert(event.data);
+      if (import.meta.env.DEV) {
+        console.error('Asset integrity verification failed', event.data);
+      }
+    }
+  });
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/service-worker.js')
+      .catch((error) => {
+        if (import.meta.env.DEV) {
+          console.error('Service worker registration failed', error);
+        }
+      });
+  });
+}


### PR DESCRIPTION
## Summary
- add a restrictive CSP header to index.html while switching Tailwind classes to a local stylesheet and wiring in the web manifest
- add a PWA manifest, icon assets, an offline fallback page, and a service worker that precaches assets with hash validation and alert messaging
- register the service worker from the React entry point so the app can receive integrity alerts from the worker

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da052ab04883298b44498c2510e222