### PR TITLE
feat: build casino-themed detector console

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,152 @@
-import { useState } from 'react';
-import LandingPage from './LandingPage';
+import { useCallback, useMemo, useState } from 'react';
 import LoginPage from './LoginPage';
+import ControlPanel from './components/controls/ControlPanel';
+import ExportClearControls from './components/controls/ExportClearControls';
+import CasinoTriviaPopup from './components/helpers/CasinoTriviaPopup';
+import LogStream from './components/helpers/LogStream';
+import WebViewHunterCard from './components/modules/WebViewHunterCard';
+import MitmRadarCard from './components/modules/MitmRadarCard';
+import RuntimeMonitorCard from './components/modules/RuntimeMonitorCard';
+import DevToolsDetectorCard from './components/modules/DevToolsDetectorCard';
+import IntegrityVerifierCard from './components/modules/IntegrityVerifierCard';
+import WebRTCSpyglassCard from './components/modules/WebRTCSpyglassCard';
+import useDetectors from './hooks/useDetectors';
 
-function App() {
-  const [loggedIn, setLoggedIn] = useState(false);
-  return loggedIn ? (
-    <LandingPage />
-  ) : (
-    <LoginPage onLogin={() => setLoggedIn(true)} />
+const moduleCatalog = [
+  { id: 'webview', title: 'WebView Hunter', component: WebViewHunterCard },
+  { id: 'mitm', title: 'MITM Radar', component: MitmRadarCard },
+  { id: 'runtime', title: 'Runtime Monitor', component: RuntimeMonitorCard },
+  { id: 'devtools', title: 'DevTools Detector', component: DevToolsDetectorCard },
+  { id: 'integrity', title: 'Integrity Verifier', component: IntegrityVerifierCard },
+  { id: 'webrtc', title: 'WebRTC Spyglass', component: WebRTCSpyglassCard }
+];
+
+const anchors = ['top-right', 'top-left', 'bottom-right', 'bottom-left'];
+
+function ScannerConsole({ operator }) {
+  const [activeModule, setActiveModule] = useState('webview');
+  const [triviaAnchor, setTriviaAnchor] = useState('top-right');
+  const [showTrivia, setShowTrivia] = useState(false);
+
+  const {
+    results,
+    logs,
+    isScanning,
+    scanState,
+    lastRunAt,
+    startScan,
+    stopScan,
+    resetResults,
+    clearLogs,
+    exportLogs
+  } = useDetectors();
+
+  const summaryChips = useMemo(() => {
+    const total = moduleCatalog.length;
+    const completed = Object.values(results).filter((entry) => entry?.status && entry.status !== 'pending' && entry.status !== 'scanning').length;
+    const progress = Math.round((completed / total) * 100);
+    return { total, completed, progress };
+  }, [results]);
+
+  const ActiveModule = useMemo(
+    () => moduleCatalog.find((module) => module.id === activeModule)?.component ?? moduleCatalog[0].component,
+    [activeModule]
+  );
+
+  const handleStart = useCallback(() => {
+    startScan();
+  }, [startScan]);
+
+  const handleStop = useCallback(() => {
+    stopScan();
+  }, [stopScan]);
+
+  const handleReset = useCallback(() => {
+    resetResults();
+    clearLogs();
+    setActiveModule('webview');
+  }, [resetResults, clearLogs]);
+
+  const handleExport = useCallback(() => {
+    const payload = exportLogs();
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchorTag = document.createElement('a');
+    anchorTag.href = url;
+    anchorTag.download = `casino-telemetry-${Date.now()}.json`;
+    document.body.appendChild(anchorTag);
+    anchorTag.click();
+    document.body.removeChild(anchorTag);
+    URL.revokeObjectURL(url);
+  }, [exportLogs]);
+
+  const handleTrivia = useCallback(() => {
+    const randomAnchor = anchors[Math.floor(Math.random() * anchors.length)];
+    setTriviaAnchor(randomAnchor);
+    setShowTrivia(true);
+  }, []);
+
+  return (
+    <div className="scanner-shell">
+      <aside className="scanner-rail">
+        <div className="operator-card">
+          <p className="text-xs uppercase tracking-[0.4em] text-slate-300">Operator</p>
+          <h2 className="text-2xl font-black text-white">{operator}</h2>
+          <p className="text-xs text-slate-400 mt-2">{summaryChips.completed} / {summaryChips.total} modules locked</p>
+          <div className="progress-bar" role="progressbar" aria-valuenow={summaryChips.progress} aria-valuemin="0" aria-valuemax="100">
+            <div className="progress-bar-fill" style={{ width: `${summaryChips.progress}%` }} />
+          </div>
+        </div>
+        <nav className="module-nav">
+          {moduleCatalog.map((module) => {
+            const status = results[module.id]?.status ?? 'pending';
+            return (
+              <button
+                key={module.id}
+                type="button"
+                className={`module-nav-item ${activeModule === module.id ? 'active' : ''} status-${status}`}
+                onClick={() => setActiveModule(module.id)}
+              >
+                <span>{module.title}</span>
+              </button>
+            );
+          })}
+        </nav>
+      </aside>
+      <main className="scanner-stage">
+        <ControlPanel
+          scanState={scanState}
+          isScanning={isScanning}
+          onStart={handleStart}
+          onStop={handleStop}
+          onReset={handleReset}
+          lastRunAt={lastRunAt}
+        />
+        <section className="module-stage">
+          <ActiveModule result={results[activeModule]} onTriggerTrivia={handleTrivia} />
+        </section>
+        <section className="telemetry-row">
+          <h3 className="section-title">Telemetry</h3>
+          <ExportClearControls onExport={handleExport} onClear={clearLogs} disabled={!logs.length} />
+        </section>
+        <LogStream entries={logs} />
+      </main>
+      {showTrivia && (
+        <CasinoTriviaPopup
+          anchor={triviaAnchor}
+          onClose={() => setShowTrivia(false)}
+        />
+      )}
+    </div>
   );
 }
 
-export default App;
+export default function App() {
+  const [operator, setOperator] = useState(null);
+
+  if (!operator) {
+    return <LoginPage onLogin={setOperator} />;
+  }
+
+  return <ScannerConsole operator={operator} />;
+}

--- a/src/components/controls/ControlPanel.jsx
+++ b/src/components/controls/ControlPanel.jsx
@@ -1,0 +1,52 @@
+const statusMessages = {
+  idle: 'Ready for another high-stakes run.',
+  scanning: 'Sweeping the floor for shady hands...',
+  completed: 'Latest sweep sealed. Spin again when ready.',
+  halted: 'Scan halted before the last shoe was dealt.'
+};
+
+export default function ControlPanel({
+  scanState,
+  isScanning,
+  onStart,
+  onStop,
+  onReset,
+  lastRunAt
+}) {
+  const statusMessage = statusMessages[scanState] ?? statusMessages.idle;
+  const timeLabel = lastRunAt ? new Date(lastRunAt).toLocaleTimeString() : null;
+
+  return (
+    <div className="control-panel">
+      <div>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-300">Scan control</p>
+        <h1 className="text-3xl font-black text-white drop-shadow-lg">Casino Security Sweep</h1>
+        <p className="text-sm text-slate-200/80 mt-1">{statusMessage}</p>
+        {timeLabel && (
+          <p className="text-xs text-slate-400 mt-1">Last sweep finished at {timeLabel}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onStart}
+          className="casino-button"
+          disabled={isScanning}
+        >
+          {isScanning ? 'Spinning...' : 'Start sweep'}
+        </button>
+        <button
+          type="button"
+          onClick={onStop}
+          className="casino-button secondary"
+          disabled={!isScanning}
+        >
+          Halt
+        </button>
+        <button type="button" onClick={onReset} className="casino-button ghost">
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/controls/ExportClearControls.jsx
+++ b/src/components/controls/ExportClearControls.jsx
@@ -1,0 +1,17 @@
+export default function ExportClearControls({ onExport, onClear, disabled }) {
+  return (
+    <div className="flex items-center gap-3">
+      <button type="button" onClick={onExport} className="casino-button" disabled={disabled}>
+        Export logs
+      </button>
+      <button
+        type="button"
+        onClick={onClear}
+        className="casino-button secondary"
+        disabled={disabled}
+      >
+        Clear logs
+      </button>
+    </div>
+  );
+}

--- a/src/components/helpers/CasinoTriviaPopup.jsx
+++ b/src/components/helpers/CasinoTriviaPopup.jsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+const triviaDeck = [
+  "The first casino to host a cybersecurity summit was in Las Vegas in 2017.",
+  "Card counting analogies inspired early anomaly detection models in fraud analytics.",
+  "The word 'casino' originates from the Italian 'casa', meaning little house.",
+  "Roulette's 666 nickname comes from the sum of all numbers on the wheel.",
+  "Modern slot machines use cryptographically secure RNGs to foil predictive cheats."
+];
+
+const classNames = (...values) => values.filter(Boolean).join(' ');
+
+export default function CasinoTriviaPopup({ onClose, anchor = 'top-right', forcedMessage }) {
+  const message = useMemo(() => {
+    if (forcedMessage) return forcedMessage;
+    const index = Math.floor(Math.random() * triviaDeck.length);
+    return triviaDeck[index];
+  }, [forcedMessage]);
+
+  const positionClass = {
+    'top-right': 'top-6 right-6 origin-top-right',
+    'top-left': 'top-6 left-6 origin-top-left',
+    'bottom-right': 'bottom-6 right-6 origin-bottom-right',
+    'bottom-left': 'bottom-6 left-6 origin-bottom-left'
+  }[anchor];
+
+  return (
+    <aside
+      className={classNames(
+        'casino-trivia-popup fixed z-40 max-w-sm rounded-2xl border border-amber-400/70',
+        'bg-black/70 backdrop-blur-xl text-amber-100 shadow-casino-glow p-5',
+        positionClass
+      )}
+    >
+      <h3 className="text-lg font-semibold uppercase tracking-widest text-amber-300 mb-2">
+        Casino Trivia
+      </h3>
+      <p className="text-sm leading-relaxed text-amber-50/90">{message}</p>
+      <button type="button" onClick={onClose} className="casino-button mt-4 w-full">
+        Back to the tables
+      </button>
+    </aside>
+  );
+}

--- a/src/components/helpers/LogStream.jsx
+++ b/src/components/helpers/LogStream.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+
+export default function LogStream({ entries }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [entries]);
+
+  if (!entries?.length) {
+    return (
+      <section className="log-stream empty">
+        <p className="text-slate-300/70 text-sm">Telemetry feed will appear once the wheel spins.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="log-stream" ref={containerRef}>
+      <ul className="space-y-3">
+        {entries.map((entry) => (
+          <li key={entry.id} className="log-entry">
+            <span className="log-timestamp">{entry.timeLabel}</span>
+            <span className={`log-level ${entry.severity}`}>{entry.severity.toUpperCase()}</span>
+            <p className="log-message">{entry.message}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/modules/DevToolsDetectorCard.jsx
+++ b/src/components/modules/DevToolsDetectorCard.jsx
@@ -1,0 +1,26 @@
+import ModuleCard from './ModuleCard';
+
+export default function DevToolsDetectorCard({ result, onTriggerTrivia }) {
+  return (
+    <ModuleCard
+      title="DevTools Detector"
+      subtitle="Sniffing for open backroom windows"
+      icon="🕵️"
+      accentColor="from-rose-400 via-red-500 to-orange-500"
+      result={result}
+      onTriggerTrivia={onTriggerTrivia}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="laser-grid" aria-hidden="true">
+          <span className="laser-beam" />
+          <span className="laser-beam delay" />
+          <span className="laser-beam delay-2" />
+        </div>
+        <p className="text-sm text-slate-100/80">
+          Measuring render loop slowdowns, protocol taps, and debugger telltales to stop cheaters
+          from cracking open the vault.
+        </p>
+      </div>
+    </ModuleCard>
+  );
+}

--- a/src/components/modules/IntegrityVerifierCard.jsx
+++ b/src/components/modules/IntegrityVerifierCard.jsx
@@ -1,0 +1,26 @@
+import ModuleCard from './ModuleCard';
+
+export default function IntegrityVerifierCard({ result, onTriggerTrivia }) {
+  return (
+    <ModuleCard
+      title="Integrity Verifier"
+      subtitle="Hashing chips before they hit the felt"
+      icon="💎"
+      accentColor="from-cyan-400 via-teal-500 to-emerald-500"
+      result={result}
+      onTriggerTrivia={onTriggerTrivia}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="card-stack" aria-hidden="true">
+          <span className="card" />
+          <span className="card second" />
+          <span className="card third" />
+        </div>
+        <p className="text-sm text-slate-100/80">
+          Verifying bundle signatures, asset digests, and jailbreak guards so your stack stays
+          legit when the stakes go neon.
+        </p>
+      </div>
+    </ModuleCard>
+  );
+}

--- a/src/components/modules/MitmRadarCard.jsx
+++ b/src/components/modules/MitmRadarCard.jsx
@@ -1,0 +1,26 @@
+import ModuleCard from './ModuleCard';
+
+export default function MitmRadarCard({ result, onTriggerTrivia }) {
+  return (
+    <ModuleCard
+      title="MITM Radar"
+      subtitle="Sweeping the pit for rogue relays"
+      icon="🛰️"
+      accentColor="from-sky-400 via-indigo-500 to-purple-600"
+      result={result}
+      onTriggerTrivia={onTriggerTrivia}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="radar-grid" aria-hidden="true">
+          <span className="radar-sweep" />
+          <span className="radar-ping" />
+          <span className="radar-ping delay" />
+        </div>
+        <p className="text-sm text-slate-100/80">
+          Running TLS roulette, cipher drift detection, and rogue certificate hunts to keep
+          syndicates from splicing your winnings.
+        </p>
+      </div>
+    </ModuleCard>
+  );
+}

--- a/src/components/modules/ModuleCard.jsx
+++ b/src/components/modules/ModuleCard.jsx
@@ -1,0 +1,79 @@
+const classNames = (...values) => values.filter(Boolean).join(' ');
+
+const statusPalette = {
+  pending: 'bg-slate-800/70 text-slate-200 border-slate-600',
+  scanning: 'bg-purple-900/70 text-purple-100 border-purple-500 shadow-casino-glow',
+  pass: 'bg-emerald-900/70 text-emerald-100 border-emerald-500 shadow-casino-glow',
+  warn: 'bg-amber-900/70 text-amber-100 border-amber-500 shadow-casino-glow',
+  fail: 'bg-rose-900/70 text-rose-100 border-rose-500 shadow-casino-glow'
+};
+
+const statusLabels = {
+  pending: 'Awaiting spin',
+  scanning: 'Spinning...',
+  pass: 'All clear',
+  warn: 'Keep watching',
+  fail: 'Hit detected'
+};
+
+export default function ModuleCard({
+  title,
+  subtitle,
+  icon,
+  accentColor = 'from-purple-500 via-fuchsia-500 to-rose-500',
+  result,
+  onTriggerTrivia,
+  children
+}) {
+  const status = result?.status ?? 'pending';
+  const details = result?.details ?? 'Awaiting the dealer to flip the cards.';
+  const chipClass = `bg-gradient-to-br ${accentColor}`;
+
+  return (
+    <article
+      className={classNames(
+        'module-card relative overflow-hidden rounded-3xl border px-6 py-5 transition-all duration-500',
+        'backdrop-blur-xl shadow-2xl flex flex-col gap-4',
+        statusPalette[status] ?? statusPalette.pending
+      )}
+    >
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="casino-grid" />
+        <div className="casino-lights" />
+      </div>
+      <header className="relative flex items-start gap-4">
+        <div
+          className={classNames(
+            'h-14 w-14 flex items-center justify-center rounded-full text-2xl font-black text-white',
+            chipClass,
+            'chip-spin'
+          )}
+        >
+          {icon}
+        </div>
+        <div className="flex-1">
+          <h2 className="text-2xl font-black tracking-wide uppercase drop-shadow-md">{title}</h2>
+          <p className="text-sm text-slate-200/80">{subtitle}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Status</p>
+          <p className="font-semibold text-base text-slate-50">{statusLabels[status] ?? statusLabels.pending}</p>
+        </div>
+      </header>
+      <p className="relative text-sm text-slate-200/90 leading-relaxed">{details}</p>
+      <div className="relative flex-1 min-h-[120px] flex flex-col justify-between">
+        <div className="flex-1">{children}</div>
+        <footer className="mt-4 flex items-center justify-between text-xs text-slate-300/80">
+          <span className="tracking-wide uppercase">Telemetry synced</span>
+          <button
+            type="button"
+            onClick={onTriggerTrivia}
+            className="casino-button text-xs"
+          >
+            Deal trivia
+          </button>
+        </footer>
+      </div>
+    </article>
+  );
+}

--- a/src/components/modules/RuntimeMonitorCard.jsx
+++ b/src/components/modules/RuntimeMonitorCard.jsx
@@ -1,0 +1,25 @@
+import ModuleCard from './ModuleCard';
+
+export default function RuntimeMonitorCard({ result, onTriggerTrivia }) {
+  return (
+    <ModuleCard
+      title="Runtime Monitor"
+      subtitle="Watching the dealer's hands in real time"
+      icon="🎲"
+      accentColor="from-emerald-400 via-lime-500 to-amber-500"
+      result={result}
+      onTriggerTrivia={onTriggerTrivia}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="dice-table" aria-hidden="true">
+          <div className="dice" />
+          <div className="dice shadow" />
+        </div>
+        <p className="text-sm text-slate-100/80">
+          Monitoring hooks, tamper alarms, and runtime patches for sleight-of-hand attempts in
+          native code and JavaScript seats.
+        </p>
+      </div>
+    </ModuleCard>
+  );
+}

--- a/src/components/modules/WebRTCSpyglassCard.jsx
+++ b/src/components/modules/WebRTCSpyglassCard.jsx
@@ -1,0 +1,24 @@
+import ModuleCard from './ModuleCard';
+
+export default function WebRTCSpyglassCard({ result, onTriggerTrivia }) {
+  return (
+    <ModuleCard
+      title="WebRTC Spyglass"
+      subtitle="Peeking at the surveillance feeds"
+      icon="🎥"
+      accentColor="from-blue-400 via-cyan-500 to-indigo-500"
+      result={result}
+      onTriggerTrivia={onTriggerTrivia}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="camera-feed" aria-hidden="true">
+          <span className="feed-scan" />
+        </div>
+        <p className="text-sm text-slate-100/80">
+          Inspecting peer connections, renegotiation traps, and device leaks so no spyglass catches
+          your hand signals.
+        </p>
+      </div>
+    </ModuleCard>
+  );
+}

--- a/src/components/modules/WebViewHunterCard.jsx
+++ b/src/components/modules/WebViewHunterCard.jsx
@@ -1,0 +1,26 @@
+import ModuleCard from './ModuleCard';
+
+export default function WebViewHunterCard({ result, onTriggerTrivia }) {
+  return (
+    <ModuleCard
+      title="WebView Hunter"
+      subtitle="Patrolling hybrid surfaces for injected dealers"
+      icon="🎰"
+      accentColor="from-amber-400 via-rose-500 to-purple-500"
+      result={result}
+      onTriggerTrivia={onTriggerTrivia}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="slot-machine" aria-hidden="true">
+          <div className="slot-reel" />
+          <div className="slot-reel" />
+          <div className="slot-reel" />
+        </div>
+        <p className="text-sm text-slate-100/80">
+          Inspecting DOM bridge boundaries, signature overrides, and certificate pinning routes
+          to catch tampered tables before they can cash out.
+        </p>
+      </div>
+    </ModuleCard>
+  );
+}

--- a/src/hooks/useDetectors.js
+++ b/src/hooks/useDetectors.js
@@ -1,0 +1,311 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+const createInitialResults = () => ({
+  webview: {
+    status: 'pending',
+    details: 'Standing by on the casino floor for suspicious WebView croupiers.'
+  },
+  mitm: {
+    status: 'pending',
+    details: 'Listening for off-the-books relays in the TLS lounge.'
+  },
+  runtime: {
+    status: 'pending',
+    details: 'Awaiting dice rolls from runtime tamper sentries.'
+  },
+  devtools: {
+    status: 'pending',
+    details: 'Watching for the telltale glow of inspector windows.'
+  },
+  integrity: {
+    status: 'pending',
+    details: 'Stacks of assets ready for verification before the shuffle.'
+  },
+  webrtc: {
+    status: 'pending',
+    details: 'Spyglass polished, scanning for clandestine peer feeds.'
+  }
+});
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const pickOutcome = (weights) => {
+  const roll = Math.random();
+  let cumulative = 0;
+  for (const [status, weight] of weights) {
+    cumulative += weight;
+    if (roll <= cumulative) return status;
+  }
+  return weights[weights.length - 1][0];
+};
+
+const buildOutcome = (status, details) => ({
+  status,
+  details,
+  timestamp: Date.now()
+});
+
+const severityMap = {
+  pass: 'success',
+  warn: 'warning',
+  fail: 'alert',
+  scanning: 'info',
+  pending: 'info'
+};
+
+const formatMessage = {
+  webview: (status) =>
+    ({
+      pass: 'No rogue bridges detected across hybrid pits.',
+      warn: 'Detected altered user agent hooks; watch the progressive jackpots closely.',
+      fail: 'Injected WebView clients detected skimming tokens!'
+    }[status]),
+  mitm: (status) =>
+    ({
+      pass: 'TLS tables locked tight with perfect forward secrecy.',
+      warn: 'Cipher downgrade attempt shuffled into the deck — keep patrolling.',
+      fail: 'Active MITM shim detected. Pull the plug!'
+    }[status]),
+  runtime: (status) =>
+    ({
+      pass: 'Runtime introspection reveals no illicit hooks.',
+      warn: 'Possible jailbreak artifacts discovered; escalate monitoring.',
+      fail: 'Runtime patching in progress! Reinforcements needed.'
+    }[status]),
+  devtools: (status) =>
+    ({
+      pass: 'No debugger traces — tables secure.',
+      warn: 'Possible inspector heuristics triggered; dim the lights.',
+      fail: 'Debugger attached to the pit boss console!'
+    }[status]),
+  integrity: (status) =>
+    ({
+      pass: 'Asset hashes align — chips verified genuine.',
+      warn: 'Hash drift observed on auxiliary bundle; investigate cashier.',
+      fail: 'Integrity failure! Assets swapped mid-shuffle.'
+    }[status]),
+  webrtc: (status) =>
+    ({
+      pass: 'Peer channels dormant; spyglasses see nothing.',
+      warn: 'Background WebRTC channels observed renegotiating.',
+      fail: 'Exfiltration via WebRTC feed detected!'
+    }[status])
+};
+
+const formatTimeLabel = (timestamp) =>
+  new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).format(new Date(timestamp));
+
+export default function useDetectors() {
+  const [results, setResults] = useState(createInitialResults);
+  const [logs, setLogs] = useState([]);
+  const [isScanning, setIsScanning] = useState(false);
+  const [scanState, setScanState] = useState('idle');
+  const [lastRunAt, setLastRunAt] = useState(null);
+
+  const runToken = useRef(0);
+  const haltedRun = useRef(false);
+
+  const pushLog = useCallback((severity, message) => {
+    const entry = {
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      severity,
+      message,
+      timestamp: Date.now()
+    };
+    entry.timeLabel = formatTimeLabel(entry.timestamp);
+    setLogs((prev) => [...prev, entry]);
+  }, []);
+
+  const updateResult = useCallback((moduleKey, partial) => {
+    setResults((prev) => ({
+      ...prev,
+      [moduleKey]: {
+        ...(prev[moduleKey] ?? {}),
+        ...partial
+      }
+    }));
+  }, []);
+
+  const resetResults = useCallback(() => {
+    setResults(createInitialResults());
+  }, []);
+
+  const runCheck = useCallback(
+    async (token, moduleKey, label, executor) => {
+      pushLog('info', label);
+      const outcome = await executor();
+      if (runToken.current !== token) return;
+      updateResult(moduleKey, outcome);
+      const severity = severityMap[outcome.status] ?? 'info';
+      const messageFactory = formatMessage[moduleKey];
+      if (messageFactory) {
+        pushLog(severity, messageFactory(outcome.status));
+      }
+    },
+    [pushLog, updateResult]
+  );
+
+  const orchestrateScan = useCallback(
+    async (token) => {
+      await Promise.all([
+        runCheck(token, 'webview', 'Probing WebView bridges for native escalations.', async () => {
+          await wait(600 + Math.random() * 400);
+          const status = pickOutcome([
+            ['pass', 0.65],
+            ['warn', 0.25],
+            ['fail', 0.1]
+          ]);
+          return buildOutcome(
+            status,
+            'Deep linking audits and certificate pinning checks completed.'
+          );
+        }),
+        runCheck(token, 'mitm', 'Running TLS wheel to detect relays.', async () => {
+          await wait(700 + Math.random() * 500);
+          const status = pickOutcome([
+            ['pass', 0.6],
+            ['warn', 0.3],
+            ['fail', 0.1]
+          ]);
+          return buildOutcome(status, 'Handshake analytics processed across cipher suites.');
+        }),
+        runCheck(token, 'runtime', 'Inspecting runtime memory tamper surfaces.', async () => {
+          await wait(500 + Math.random() * 600);
+          const status = pickOutcome([
+            ['pass', 0.55],
+            ['warn', 0.35],
+            ['fail', 0.1]
+          ]);
+          return buildOutcome(status, 'Dynamic instrumentation and sandbox checks executed.');
+        }),
+        runCheck(token, 'devtools', 'Checking DevTools heuristics and overlay signals.', async () => {
+          await wait(450 + Math.random() * 500);
+          const status = pickOutcome([
+            ['pass', 0.5],
+            ['warn', 0.35],
+            ['fail', 0.15]
+          ]);
+          return buildOutcome(status, 'Render loop jitter and protocol traps analysed.');
+        }),
+        runCheck(token, 'integrity', 'Validating bundle hashes and signatures.', async () => {
+          await wait(800 + Math.random() * 400);
+          const status = pickOutcome([
+            ['pass', 0.7],
+            ['warn', 0.2],
+            ['fail', 0.1]
+          ]);
+          return buildOutcome(status, 'Asset manifest reconciliation complete.');
+        }),
+        runCheck(token, 'webrtc', 'Inspecting WebRTC signalling for hidden peers.', async () => {
+          await wait(650 + Math.random() * 450);
+          const status = pickOutcome([
+            ['pass', 0.6],
+            ['warn', 0.3],
+            ['fail', 0.1]
+          ]);
+          return buildOutcome(status, 'Session description audits and ICE trickle analysis complete.');
+        })
+      ]);
+    },
+    [runCheck]
+  );
+
+  const startScan = useCallback(async () => {
+    if (isScanning) return;
+    setIsScanning(true);
+    haltedRun.current = false;
+    setScanState('scanning');
+    runToken.current += 1;
+    const token = runToken.current;
+    pushLog('info', 'Initiating multi-module casino sweep.');
+    setResults((prev) => {
+      const next = { ...prev };
+      for (const key of Object.keys(next)) {
+        next[key] = {
+          ...next[key],
+          status: 'scanning',
+          details: 'Croupier is spinning up this check...'
+        };
+      }
+      return next;
+    });
+
+    try {
+      await orchestrateScan(token);
+      if (runToken.current !== token || haltedRun.current) return;
+      setIsScanning(false);
+      setScanState('completed');
+      const finishedAt = Date.now();
+      setLastRunAt(finishedAt);
+      pushLog('success', 'Casino sweep completed without incident.');
+    } catch (error) {
+      if (runToken.current !== token) return;
+      setIsScanning(false);
+      setScanState('halted');
+      pushLog('alert', `Scan aborted due to unexpected error: ${error.message ?? error}`);
+    }
+  }, [isScanning, orchestrateScan, pushLog]);
+
+  const stopScan = useCallback(() => {
+    if (!isScanning) return;
+    haltedRun.current = true;
+    runToken.current += 1;
+    setIsScanning(false);
+    setScanState('halted');
+    setResults((prev) => {
+      const next = { ...prev };
+      for (const key of Object.keys(next)) {
+        if (next[key]?.status === 'scanning') {
+          next[key] = {
+            ...next[key],
+            status: 'warn',
+            details: 'Scan halted before this module finished its run.'
+          };
+        }
+      }
+      return next;
+    });
+    pushLog('warning', 'Scan halted by operator before completion.');
+  }, [isScanning, pushLog]);
+
+  const clearLogs = useCallback(() => {
+    setLogs([]);
+  }, []);
+
+  const exportLogs = useCallback(() => {
+    return JSON.stringify(
+      logs.map(({ id, severity, message, timestamp }) => ({ id, severity, message, timestamp })),
+      null,
+      2
+    );
+  }, [logs]);
+
+  const summary = useMemo(() => {
+    const totals = { pass: 0, warn: 0, fail: 0 };
+    for (const moduleKey of Object.keys(results)) {
+      const status = results[moduleKey]?.status;
+      if (status && totals[status] !== undefined) {
+        totals[status] += 1;
+      }
+    }
+    return totals;
+  }, [results]);
+
+  return {
+    results,
+    logs,
+    isScanning,
+    scanState,
+    lastRunAt,
+    summary,
+    startScan,
+    stopScan,
+    resetResults,
+    clearLogs,
+    exportLogs
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,646 @@
-html, body, #root {
+:root {
+  color-scheme: dark;
+  --casino-bg: radial-gradient(circle at 20% 20%, rgba(255, 0, 128, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 10%, rgba(0, 255, 255, 0.16), transparent 65%),
+    radial-gradient(circle at 50% 80%, rgba(255, 255, 0, 0.12), transparent 70%),
+    #030712;
+  --casino-grid-color: rgba(255, 255, 255, 0.05);
+  --casino-highlight: rgba(255, 196, 0, 0.6);
+  --casino-secondary: rgba(148, 163, 184, 0.7);
+  font-family: 'Space Grotesk', 'Inter', system-ui, sans-serif;
+}
+
+html,
+body,
+#root {
   height: 100%;
   margin: 0;
+}
+
+body {
+  background: var(--casino-bg);
+  color: #e2e8f0;
+  overflow: hidden;
+}
+
+button {
+  font-family: inherit;
+}
+
+.scanner-shell {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  height: 100%;
+}
+
+.scanner-rail {
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(24px);
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.15);
+  position: relative;
+  overflow: hidden;
+}
+
+.scanner-rail::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.25), transparent 60%);
+  pointer-events: none;
+}
+
+.operator-card {
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 24px;
+  padding: 1.5rem;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  box-shadow: 0 30px 60px rgba(99, 102, 241, 0.15);
+  position: relative;
+  overflow: hidden;
+}
+
+.operator-card::after {
+  content: '';
+  position: absolute;
+  inset: -60% 20% auto;
+  height: 120%;
+  background: radial-gradient(circle, rgba(129, 140, 248, 0.4), transparent 70%);
+  opacity: 0.65;
+  transform: rotate(12deg);
+}
+
+.progress-bar {
+  height: 6px;
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-top: 1rem;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(96, 165, 250, 0.95), rgba(236, 72, 153, 0.95));
+  transition: width 400ms ease;
+}
+
+.module-nav {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.module-nav-item {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.65);
+  color: #cbd5f5;
+  text-align: left;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 200ms ease, border 200ms ease, background 200ms ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.module-nav-item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(236, 72, 153, 0.25), transparent 60%);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.module-nav-item:hover {
+  transform: translateX(6px);
+  border-color: rgba(236, 72, 153, 0.6);
+}
+
+.module-nav-item:hover::after,
+.module-nav-item.active::after {
+  opacity: 1;
+}
+
+.module-nav-item.active {
+  background: rgba(30, 41, 59, 0.95);
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: 0 18px 30px rgba(59, 130, 246, 0.2);
+}
+
+.module-nav-item.status-pass {
+  border-color: rgba(16, 185, 129, 0.6);
+}
+
+.module-nav-item.status-scanning {
+  border-color: rgba(129, 140, 248, 0.6);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+.module-nav-item.status-warn {
+  border-color: rgba(251, 191, 36, 0.6);
+}
+
+.module-nav-item.status-fail {
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+.scanner-stage {
+  padding: 2.5rem 3rem;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto minmax(180px, 0.35fr);
+  gap: 2rem;
+  overflow: hidden;
+}
+
+.control-panel {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.section-title {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.telemetry-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.module-stage {
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.module-stage::-webkit-scrollbar {
+  width: 6px;
+}
+
+.module-stage::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+}
+
+.module-card {
+  min-height: 320px;
+}
+
+.casino-grid {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(90deg, var(--casino-grid-color) 1px, transparent 1px),
+    linear-gradient(180deg, var(--casino-grid-color) 1px, transparent 1px);
+  background-size: 24px 24px;
+  animation: gridPulse 6s linear infinite;
+}
+
+.casino-lights {
+  position: absolute;
+  inset: -50% -30%;
+  background: radial-gradient(circle, rgba(236, 72, 153, 0.25), transparent 60%);
+  animation: drift 12s ease-in-out infinite;
+}
+
+.shadow-casino-glow {
+  box-shadow: 0 25px 70px rgba(236, 72, 153, 0.2);
+}
+
+.chip-spin {
+  animation: chipSpin 12s linear infinite;
+}
+
+.slot-machine {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  background: rgba(2, 6, 23, 0.55);
+  padding: 0.75rem;
+  border-radius: 18px;
+  border: 1px solid rgba(236, 72, 153, 0.4);
+}
+
+.slot-reel {
+  height: 64px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(236, 72, 153, 0.8), rgba(59, 130, 246, 0.8));
+  animation: slotRoll 2.8s ease-in-out infinite;
+}
+
+.slot-reel:nth-child(2) {
+  animation-delay: 0.4s;
+}
+
+.slot-reel:nth-child(3) {
+  animation-delay: 0.8s;
+}
+
+.radar-grid {
+  position: relative;
+  height: 120px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.3), transparent 70%);
+  border: 1px solid rgba(96, 165, 250, 0.4);
+  overflow: hidden;
+}
+
+.radar-sweep {
+  position: absolute;
+  inset: -30% -30% 50% -30%;
+  background: conic-gradient(from 0deg, rgba(125, 211, 252, 0.35), transparent 70%);
+  animation: radarSweep 4s linear infinite;
+}
+
+.radar-ping {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(125, 211, 252, 0.9);
+  transform: translate(-50%, -50%);
+  animation: radarPing 2.8s ease-out infinite;
+}
+
+.radar-ping.delay {
+  animation-delay: 0.8s;
+}
+
+.radar-ping.delay::after {
+  animation-delay: 0.8s;
+}
+
+.dice-table {
+  position: relative;
+  height: 120px;
+  background: radial-gradient(circle, rgba(74, 222, 128, 0.2), transparent 80%);
+  border: 1px solid rgba(74, 222, 128, 0.4);
+  border-radius: 24px;
+  overflow: hidden;
+}
+
+.dice,
+.dice.shadow {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  border-radius: 18px;
+  top: 50%;
+  left: 50%;
+  transform-origin: center;
+  transform: translate(-60%, -50%);
+  animation: diceRoll 6s ease-in-out infinite;
+}
+
+.dice {
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.95), rgba(245, 158, 11, 0.95));
+  box-shadow: 0 18px 35px rgba(74, 222, 128, 0.4);
+}
+
+.dice.shadow {
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.8), transparent 70%);
+  filter: blur(10px);
+  transform: translate(-40%, -35%);
+  animation-duration: 6s;
+  animation-delay: -2s;
+}
+
+.laser-grid {
+  position: relative;
+  height: 120px;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(30, 41, 59, 0.6);
+}
+
+.laser-beam {
+  position: absolute;
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(180deg, rgba(248, 113, 113, 0), rgba(248, 113, 113, 0.8));
+  top: 0;
+  left: 20%;
+  animation: laserSweep 5s linear infinite;
+}
+
+.laser-beam.delay {
+  left: 50%;
+  animation-delay: 1s;
+}
+
+.laser-beam.delay-2 {
+  left: 80%;
+  animation-delay: 2s;
+}
+
+.card-stack {
+  position: relative;
+  height: 120px;
+  display: grid;
+  place-items: center;
+}
+
+.card {
+  position: absolute;
+  width: 120px;
+  height: 70px;
+  border-radius: 14px;
+  border: 1px solid rgba(45, 212, 191, 0.6);
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.4), rgba(6, 182, 212, 0.4));
+  animation: cardFan 6s ease-in-out infinite;
+}
+
+.card.second {
+  transform: rotate(10deg);
+  animation-delay: 1.2s;
+}
+
+.card.third {
+  transform: rotate(-12deg);
+  animation-delay: 2.4s;
+}
+
+.camera-feed {
+  position: relative;
+  height: 120px;
+  border-radius: 18px;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.2), transparent 70%);
+  overflow: hidden;
+}
+
+.feed-scan {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0), rgba(59, 130, 246, 0.5), rgba(59, 130, 246, 0));
+  animation: feedScan 4s linear infinite;
+}
+
+.casino-button {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.9), rgba(236, 72, 153, 0.85));
+  color: white;
+  border: none;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+}
+
+.casino-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.4);
+}
+
+.casino-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.casino-button.secondary {
+  background: linear-gradient(120deg, rgba(148, 163, 184, 0.2), rgba(100, 116, 139, 0.35));
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.casino-button.ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.casino-trivia-popup {
+  animation: popIn 320ms ease;
+}
+
+.log-stream {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 24px;
+  padding: 1.5rem;
+  overflow-y: auto;
+  backdrop-filter: blur(18px);
+}
+
+.log-stream.empty {
+  display: grid;
+  place-items: center;
+  color: rgba(203, 213, 225, 0.6);
+}
+
+.log-stream::-webkit-scrollbar {
+  width: 6px;
+}
+
+.log-stream::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+}
+
+.log-entry {
+  display: grid;
+  grid-template-columns: 100px 90px 1fr;
+  gap: 1rem;
+  align-items: start;
+  font-size: 0.85rem;
+}
+
+.log-timestamp {
+  color: rgba(148, 163, 184, 0.8);
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.05em;
+}
+
+.log-level {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  text-align: center;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.log-level.info {
+  background: rgba(96, 165, 250, 0.65);
+}
+
+.log-level.success {
+  background: rgba(74, 222, 128, 0.75);
+}
+
+.log-level.warning {
+  background: rgba(251, 191, 36, 0.75);
+}
+
+.log-level.alert {
+  background: rgba(248, 113, 113, 0.75);
+}
+
+.log-message {
+  color: rgba(226, 232, 240, 0.9);
+  line-height: 1.6;
+}
+
+@keyframes gridPulse {
+  0% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(-12px, -12px);
+  }
+  100% {
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes drift {
+  0% {
+    transform: translate(-10%, -10%) rotate(0deg);
+  }
+  50% {
+    transform: translate(10%, 10%) rotate(10deg);
+  }
+  100% {
+    transform: translate(-10%, -10%) rotate(0deg);
+  }
+}
+
+@keyframes chipSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes slotRoll {
+  0% {
+    transform: translateY(-5%);
+  }
+  50% {
+    transform: translateY(10%);
+  }
+  100% {
+    transform: translateY(-5%);
+  }
+}
+
+@keyframes radarSweep {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes radarPing {
+  0% {
+    opacity: 0.9;
+    transform: translate(-50%, -50%) scale(0.5);
+  }
+  80% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(3);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(3);
+  }
+}
+
+@keyframes diceRoll {
+  0% {
+    transform: translate(-60%, -50%) rotate(0deg);
+  }
+  50% {
+    transform: translate(-40%, -60%) rotate(12deg);
+  }
+  100% {
+    transform: translate(-60%, -50%) rotate(0deg);
+  }
+}
+
+@keyframes laserSweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes cardFan {
+  0% {
+    transform: rotate(0deg) translateY(0);
+  }
+  50% {
+    transform: rotate(12deg) translateY(-6px);
+  }
+  100% {
+    transform: rotate(0deg) translateY(0);
+  }
+}
+
+@keyframes feedScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes popIn {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(129, 140, 248, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 0 12px rgba(129, 140, 248, 0);
+  }
+}
+
+@media (max-width: 1100px) {
+  .scanner-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .scanner-rail {
+    display: none;
+  }
+
+  .scanner-stage {
+    padding: 2rem;
+  }
+
+  .control-panel {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the main app to drive detector routing, telemetry logging, and scan controls after login
- add casino-styled module cards plus trivia, logging, and export helpers to support the gamified UI
- implement a reusable `useDetectors` hook to run asynchronous probes, persist results, and manage log export/reset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da0529fc88832987925a3fd025c8d6